### PR TITLE
Websocket client can now stream messages to user-supplied queue

### DIFF
--- a/aiokubernetes/config/kube_config.py
+++ b/aiokubernetes/config/kube_config.py
@@ -498,7 +498,9 @@ def new_client_from_config(
 def new_websocket_client_from_config(
         config_file=None,
         context=None,
-        persist_config=True):
+        persist_config=True,
+        queue=None,
+):
     """Loads configuration the same as load_kube_config but returns an ApiClient
     to be used with any API object. This will allow the caller to concurrently
     talk with multiple clusters."""
@@ -506,4 +508,4 @@ def new_websocket_client_from_config(
     load_kube_config(config_file=config_file, context=context,
                      client_configuration=client_config,
                      persist_config=persist_config)
-    return WebsocketApiClient(configuration=client_config)
+    return WebsocketApiClient(configuration=client_config, queue=queue)

--- a/aiokubernetes/stream/ws_client.py
+++ b/aiokubernetes/stream/ws_client.py
@@ -24,7 +24,7 @@ RESIZE_CHANNEL = 4
 
 def get_websocket_url(url):
     parts = urlparse(url)
-    assert parts.scheme in ('http', 'https')
+    assert parts.scheme in ('http', 'https'), f'Unknown scheme <{parts.scheme}>'
     new_scheme = 'ws' if parts.scheme == 'http' else 'wss'
     return urlunparse(parts._replace(scheme=new_scheme))
 

--- a/aiokubernetes/stream/ws_client_test.py
+++ b/aiokubernetes/stream/ws_client_test.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 from types import SimpleNamespace
 
 import asynctest
-from asynctest import CoroutineMock, TestCase, patch, mock
+from asynctest import TestCase, mock
 
 import aiokubernetes as k8s
 from aiokubernetes.stream import WebsocketApiClient
@@ -53,9 +54,10 @@ class WSClientTest(TestCase):
     async def test_exec_ws(self, m_rest):
         """Verify the Websocket connection sends the correct headers."""
 
-        # Iterator mock to simulate a websocket connection. Aiohttp uses
-        # async context managers which is why need to turn this mock object
-        # into an async context manager afterwards as well.
+        # Mocked async iterator to simulate the message streaming in from a
+        # websocket connection. We must also turn this mock into an async
+        # context managers because this is what `aiohttp` does and our
+        # WebsocketApiClient assumes it deals with `aiohttp`.
         m_ws = asynctest.mock.MagicMock()
         m_ws.__aiter__.return_value = [
             SimpleNamespace(data=(chr(1) + 'message1 ').encode('utf-8')),
@@ -63,6 +65,8 @@ class WSClientTest(TestCase):
         ]
         m_ws.__aenter__.return_value = m_ws.__aexit__.return_value = m_ws
 
+        # Stub out the Rest client that will ultimately be called on to create
+        # the Websocket connection.
         m_rest.RESTClientObject.return_value.pool_manager = m_rest
         m_rest.ws_connect.return_value = m_ws
 
@@ -87,6 +91,41 @@ class WSClientTest(TestCase):
                 'Content-Type': 'application/json'
             }
         )
+
+    @mock.patch.object(k8s.api_client, 'rest')
+    async def test_ws_put_messages_into_queue(self, m_rest):
+        """Messages must go into a queue as they stream in."""
+
+        # Mocked async iterator to simulate the message streaming in from a
+        # websocket connection. We must also turn this mock into an async
+        # context managers because this is what `aiohttp` does and our
+        # WebsocketApiClient assumes it deals with `aiohttp`.
+        m_ws = asynctest.mock.MagicMock()
+        m_ws.__aiter__.return_value = [
+            SimpleNamespace(data=(b'message1 ')),
+            SimpleNamespace(data=(b'message2 ')),
+        ]
+        m_ws.__aenter__.return_value = m_ws.__aexit__.return_value = m_ws
+
+        # Stub out the Rest client that will ultimately be called on to create
+        # the Websocket connection.
+        m_rest.RESTClientObject.return_value.pool_manager = m_rest
+        m_rest.ws_connect.return_value = m_ws
+
+        queue = asyncio.Queue()
+
+        # Make the websocket request through our Mock. Pass our Queue along to
+        # the WebsocketClient to receive message immediately.
+        ws = k8s.CoreV1Api(api_client=WebsocketApiClient(queue=queue))
+        await ws.connect_get_namespaced_pod_exec(
+            'pod', 'namespace', command="mock-command",
+            stderr=True, stdin=False, stdout=True, tty=False
+        )
+
+        # Messages must also have been pushed into the queue as they came in.
+        assert queue.qsize() == 2
+        self.assertEqual(await queue.get(), b'message1 ')
+        self.assertEqual(await queue.get(), b'message2 ')
 
 
 if __name__ == '__main__':

--- a/aiokubernetes/stream/ws_client_test.py
+++ b/aiokubernetes/stream/ws_client_test.py
@@ -15,6 +15,7 @@
 import asyncio
 from types import SimpleNamespace
 
+import aiohttp
 import asynctest
 from asynctest import TestCase, mock
 
@@ -60,8 +61,8 @@ class WSClientTest(TestCase):
         # WebsocketApiClient assumes it deals with `aiohttp`.
         m_ws = asynctest.mock.MagicMock()
         m_ws.__aiter__.return_value = [
-            SimpleNamespace(data=(chr(1) + 'message1 ').encode('utf-8')),
-            SimpleNamespace(data=(chr(1) + 'message2 ').encode('utf-8')),
+            SimpleNamespace(data=(b'\x01message1 '), type=aiohttp.WSMsgType.BINARY),
+            SimpleNamespace(data=(b'\x01message2 '), type=aiohttp.WSMsgType.BINARY),
         ]
         m_ws.__aenter__.return_value = m_ws.__aexit__.return_value = m_ws
 
@@ -102,8 +103,8 @@ class WSClientTest(TestCase):
         # WebsocketApiClient assumes it deals with `aiohttp`.
         m_ws = asynctest.mock.MagicMock()
         m_ws.__aiter__.return_value = [
-            SimpleNamespace(data=(b'message1 ')),
-            SimpleNamespace(data=(b'message2 ')),
+            SimpleNamespace(data=(b'\x01message1 '), type=aiohttp.WSMsgType.BINARY),
+            SimpleNamespace(data=(b'\x01message2 '), type=aiohttp.WSMsgType.BINARY),
         ]
         m_ws.__aenter__.return_value = m_ws.__aexit__.return_value = m_ws
 
@@ -124,8 +125,8 @@ class WSClientTest(TestCase):
 
         # Messages must also have been pushed into the queue as they came in.
         assert queue.qsize() == 2
-        self.assertEqual(await queue.get(), b'message1 ')
-        self.assertEqual(await queue.get(), b'message2 ')
+        self.assertEqual(await queue.get(), b'\x01message1 ')
+        self.assertEqual(await queue.get(), b'\x01message2 ')
 
 
 if __name__ == '__main__':

--- a/aiokubernetes/stream/ws_client_test.py
+++ b/aiokubernetes/stream/ws_client_test.py
@@ -39,6 +39,16 @@ class WSClientTest(TestCase):
         for url, ws_url in in_out:
             self.assertEqual(get_websocket_url(url), ws_url)
 
+            # The parser must cope with non-lower case schemes (eg
+            # HTtp://foo.com) but always return strictly lower-case versions
+            # (eg http://foo.com).
+            url_upper = url.replace('http', 'HtTp')
+            self.assertEqual(get_websocket_url(url_upper), ws_url)
+
+        # Hard abort for unknown schemes.
+        with self.assertRaises(AssertionError):
+            get_websocket_url('foo://bar.com')
+
     async def test_exec_ws(self):
 
         class WsMock:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 REQUIRES = open('requirements.txt').readlines()
 TESTS_REQUIRES = open('test-requirements.txt').readlines()
 
-CLIENT_VERSION = "0.2"
+CLIENT_VERSION = "0.3"
 PACKAGE_NAME = "aiokubernetes"
 DEVELOPMENT_STATUS = "3 - Alpha"
 


### PR DESCRIPTION
The optional queue makes it possible to stream Websocket message as they arrive instead of having to wait until the connection closes. Ths is particularly useful for long-running operations inside a Pod that produce intermediate output.

This PR made the following additions:
- Add optional queue argument to `WebsocketApiClient`
- Added queue demo to `examples/all_in_one.py`
- Improved and extended the existing `ws_client_test.py` test suite.