### PR TITLE
Add dedicated `shutdown` method to ApiClient

### DIFF
--- a/aiokubernetes/api_client.py
+++ b/aiokubernetes/api_client.py
@@ -100,6 +100,9 @@ class ApiClient(object):
     def user_agent(self, value):
         self.default_headers['User-Agent'] = value
 
+    async def close(self):
+        await self.session.close()
+
     def set_default_header(self, header_name, header_value):
         self.default_headers[header_name] = header_value
 

--- a/examples/all_in_one.py
+++ b/examples/all_in_one.py
@@ -132,7 +132,7 @@ async def setup():
     await asyncio.gather(*tasks)
 
     print('\nShutting down')
-    await api_client.session.close()
+    await api_client.close()
 
 
 def main():

--- a/examples/list_pods.py
+++ b/examples/list_pods.py
@@ -20,7 +20,7 @@ async def main():
         print(f"{i.metadata.namespace} {i.metadata.name}")
 
     # Terminate the connection pool for a clean shutdown.
-    await api_client.session.close()
+    await api_client.close()
 
 
 if __name__ == '__main__':

--- a/examples/multi_cluster.py
+++ b/examples/multi_cluster.py
@@ -7,11 +7,10 @@ import aiokubernetes as k8s
 
 async def watch_resource(cluster_name, resource, **kwargs):
     async for event in k8s.Watch(resource, **kwargs):
-        etype, obj = event['type'], event['object']
-        print(f"{cluster_name}: {etype} {obj.kind} {obj.metadata.name}")
+        print(f"{event.name} {event.obj.kind} {event.obj.metadata.name}")
 
 
-async def setup(kubeconf_a, kubeconf_b):
+async def start(kubeconf_a, kubeconf_b):
     # Create client API instances to each cluster.
     api_client_a = k8s.config.new_client_from_config(kubeconf_a)
     api_client_b = k8s.config.new_client_from_config(kubeconf_b)
@@ -39,7 +38,7 @@ def main():
     args = parser.parse_args()
 
     # Setup the main task.
-    task = setup(args.kubeconfig_a, args.kubeconfig_b)
+    task = start(args.kubeconfig_a, args.kubeconfig_b)
 
     # Setup event loop and setup the program.
     loop = asyncio.get_event_loop()

--- a/examples/multi_cluster.py
+++ b/examples/multi_cluster.py
@@ -23,8 +23,8 @@ async def start(kubeconf_a, kubeconf_b):
     await asyncio.gather(*tasks)
 
     # Terminate the connection pool for a clean shutdown.
-    await api_client_a.session.close()
-    await api_client_b.session.close()
+    await api_client_a.close()
+    await api_client_b.close()
 
 
 def main():

--- a/examples/watch_resources.py
+++ b/examples/watch_resources.py
@@ -29,7 +29,7 @@ async def main():
     await asyncio.gather(*tasks)
 
     # Terminate the connection pool for a clean shutdown.
-    await api_client.session.close()
+    await api_client.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR removes the need to know about the `session` instance inside `ApiClient` and provides one obvious way to shut down the client.