### PR TITLE
Added service account authentication

### DIFF
--- a/aiokubernetes/api_client.py
+++ b/aiokubernetes/api_client.py
@@ -218,7 +218,10 @@ class ApiClient(object):
                 data = await response_data.json()
 
                 # fixup: intercept ValueError (data may be none because request failed)
-                return_data = k8s.swagger.deserialize(data, response_type)
+                try:
+                    return_data = k8s.swagger.deserialize(data, response_type)
+                except ValueError:
+                    return_data = None
         else:
             return_data = None
 

--- a/aiokubernetes/api_client.py
+++ b/aiokubernetes/api_client.py
@@ -216,6 +216,8 @@ class ApiClient(object):
 
                 # fetch data from response object
                 data = await response_data.json()
+
+                # fixup: intercept ValueError (data may be none because request failed)
                 return_data = k8s.swagger.deserialize(data, response_type)
         else:
             return_data = None

--- a/aiokubernetes/config/__init__.py
+++ b/aiokubernetes/config/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import aiokubernetes.config.incluster_config
 from .config_exception import ConfigException
-from .incluster_config import load_incluster_config
 from .kube_config import (list_kube_config_contexts, load_kube_config,
                           new_client_from_config)

--- a/examples/deploy-pod-with-sa.yaml
+++ b/examples/deploy-pod-with-sa.yaml
@@ -1,0 +1,114 @@
+# -----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# Launch a Pod with a service account that grants it Kubernetes access.
+#
+# The pod will launch into the dedicated `aiokubernetes` namespace so as to
+# not accidentally overwrite existing roles or deployments.
+#
+# Create: `kubectl apply -f deploy-pod-with-sa.yaml`
+# Delete: `kubectl delete -f deploy-pod-with-sa.yaml`
+# -----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Create the "aiokubernetes" namespace.
+# -----------------------------------------------------------------------------
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aiokubernetes
+
+---
+
+# -----------------------------------------------------------------------------
+# Define the `aiokubernetes-role` role and give it permission to query
+# information about namespaces, deployments, etc in the entire cluster.
+# -----------------------------------------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aiokubernetes-role
+
+rules:
+- apiGroups: ["", "extensions"]
+  resources:
+  - deployments
+  - namespaces
+  - pods
+  - replicasets
+  verbs: ["get", "list", "watch"]
+
+- apiGroups: ["batch", "extensions"]
+  resources:
+  - jobs
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+---
+
+# -----------------------------------------------------------------------------
+# Create the "aiokubernetes-sa" service account. By itself this is useless
+# because it does not grant access to anything. In the next step we will make
+# it useful and associate it with the above defined above, but here we really
+# just create the service account named `aiokubernetes-sa`.
+# -----------------------------------------------------------------------------
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aiokubernetes-sa
+  namespace: aiokubernetes
+
+---
+
+# -----------------------------------------------------------------------------
+# Grant the service account `aiokubernetes-sa` the permissions defined for
+# `aiokubernetes-role`. Now the service account credentials will actually
+# become useful for the pod that has access to it (next step).
+# -----------------------------------------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aiokubernetes-binding
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aiokubernetes-role
+
+subjects:
+- kind: ServiceAccount
+  name: aiokubernetes-sa
+  namespace: aiokubernetes
+
+---
+
+# -----------------------------------------------------------------------------
+# Create a Python pod with the service account we just configured.
+# -----------------------------------------------------------------------------
+apiVersion: extensions/v1beta1
+kind: Deployment
+
+metadata:
+  name: login
+  namespace: aiokubernetes
+
+spec:
+  replicas: 1
+
+  template:
+    metadata:
+      labels:
+        app: login
+
+    spec:
+      # Allow these container to use the Service Account credentials we
+      # configured earlier.
+      serviceAccountName: aiokubernetes-sa
+  
+      # Launch a Python 3.6 container that waits for a long time. This #
+      # "trick" will keep the Pod alive and we can `exec` into the pod and run
+      # commands ourselves.
+      containers:
+        - name: login
+          image: python:3.6
+          command: ["sleep", "10000d"]
+          imagePullPolicy: IfNotPresent

--- a/examples/incluster.py
+++ b/examples/incluster.py
@@ -1,0 +1,34 @@
+"""Use service account credentials to list all pods in the cluster.
+
+NOTE: must run inside a Pod with the correct service account credentials. See
+`deploy-pod-with-sa.yaml` for an example to set this up.
+"""
+import asyncio
+
+import aiokubernetes as k8s
+
+
+async def main():
+    # Assume we are inside a Pod and load its service account credentials.
+    client_config = k8s.config.incluster_config.load_service_account_config()
+
+    # Create a client with the service account credentials.
+    api_client = k8s.api_client.ApiClient(configuration=client_config)
+
+    # Ask for all Pods - no different than when running locally.
+    v1 = k8s.api.CoreV1Api(api_client)
+    ret = await v1.list_pod_for_all_namespaces()
+    assert ret.http.status == 200
+
+    # Print the pod names.
+    for i in ret.obj.items:
+        print(f"{i.metadata.namespace} {i.metadata.name}")
+
+    # Close all pending connections.
+    await api_client.close()
+
+
+if __name__ == '__main__':
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())
+    loop.close()


### PR DESCRIPTION
This PR replaces the original `InClusterConfigLoader` class with a flat function to do the same. The primary difference is that this new `load_service_account_config` function will explicitly return the `Configuration` object and not tacitly install it as the global default.

The PR also adds a new example to show how in-cluster authentication works, along with a K8s manifest to create a pod and service account with the necessary permissions.