### PR TITLE
Create v0.6

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -4,9 +4,10 @@ Quickstart
 
 .. note::
 
-   These notes are for v0.4 only. Version 0.5 introduced a breaking change to
+   These notes are for v0.4 only. Version 0.6 introduced a breaking change to
    accomodate the Rest client of your choice (async or not). Please see the
-   Readme and files in the `examples/` folder for v0.5 usage examples.
+   Readme and files in the `examples/` folder for v0.6 usage examples. There is
+   no version v0.5.
 
 
 .. currentmodule:: aiokubernetes

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 REQUIRES = open('requirements.txt').readlines()
 TESTS_REQUIRES = open('test-requirements.txt').readlines()
 
-CLIENT_VERSION = "0.5"
+CLIENT_VERSION = "0.6"
 PACKAGE_NAME = "aiokubernetes"
 DEVELOPMENT_STATUS = "4 - Beta"
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'aiokubernetes',
         'aiokubernetes.api',
         'aiokubernetes.config',
-        'aiokubernetes.watch',
         'aiokubernetes.models',
     ],
     include_package_data=True,


### PR DESCRIPTION
This PR fixes an accidentally introduced version inconsistency. It upgrades all version tags to v0.6. There is no official version v0.5.