### PR TITLE
Support SSL contexts with aiohttp

### DIFF
--- a/aiokubernetes/clients.py
+++ b/aiokubernetes/clients.py
@@ -16,9 +16,13 @@ def get_aiohttp(config):
     Returns:
         Requests session instance.
     """
+    ssl_context = ssl.create_default_context(cafile=config.ssl_ca_cert)
+    if config.cert_file:
+        ssl_context.load_cert_chain(config.cert_file, keyfile=config.key_file)
+
     connector = aiohttp.TCPConnector(
         limit=4,
-        ssl_context=ssl.create_default_context(cafile=config.ssl_ca_cert),
+        ssl_context=ssl_context,
         verify_ssl=config.verify_ssl  # Bool, usually True.
     )
     return aiohttp.ClientSession(connector=connector)

--- a/aiokubernetes/utils.py
+++ b/aiokubernetes/utils.py
@@ -22,9 +22,6 @@ def load_config(config_file=None, context=None, warn=True):
     if config_file is None:
         config_file = os.path.expanduser(os.environ.get('KUBECONFIG', '~/.kube/config'))
 
-    # Create dummy configuration.
-    config = k8s.configuration.Configuration()
-
     loader = k8s.config.kube_config._get_kube_config_loader_for_yaml_file(
         config_file,
         active_context=context,
@@ -32,8 +29,9 @@ def load_config(config_file=None, context=None, warn=True):
     )
 
     # Load the token and refresh it, if necessary. Suppress all warnings if
-    # asked. This option will suppress an annoying Google Auth library message
-    # that warns about using your kubeconfig file instead of service accounts.
+    # asked to (skips an annoying Google Auth library message that recommends
+    # to use service accounts instead of a kubeconfig file).
+    config = k8s.configuration.Configuration()
     if warn:
         loader.load_and_set(config)
     else:

--- a/aiokubernetes/utils.py
+++ b/aiokubernetes/utils.py
@@ -22,6 +22,7 @@ def load_config(config_file=None, context=None, warn=True):
     if config_file is None:
         config_file = os.path.expanduser(os.environ.get('KUBECONFIG', '~/.kube/config'))
 
+    # fixup: trap FileNotFoundError here and return None.
     loader = k8s.config.kube_config._get_kube_config_loader_for_yaml_file(
         config_file,
         active_context=context,

--- a/aiokubernetes/watch.py
+++ b/aiokubernetes/watch.py
@@ -52,7 +52,7 @@ class AioHttpClientWatch(object):
         if len(line) == 0:
             raise StopAsyncIteration
 
-        # Return then unpacked response.
+        # Return the unpacked response.
         name, obj = k8s.swagger.unpack_watch(line)
         return WatchResponse(name=name, raw=line, obj=obj)
 


### PR DESCRIPTION
This change makes it possible to use `aiohttp` client packages with `aiokubernetes` with Minikube.